### PR TITLE
Added overload for Throws method in Return and Void behaviours.

### DIFF
--- a/HyperMock/CallInfo.cs
+++ b/HyperMock/CallInfo.cs
@@ -13,7 +13,7 @@ namespace HyperMock.Universal
         internal string Name { get; set; }
         internal Parameter[] Parameters { get; set; }
         internal object ReturnValue { get; set; }
-        internal Type ExceptionType { get; set; }
+        internal Exception Exception { get; set; }
         internal int Visited { get; set; }
         internal bool IsEvent { get; set; }
 

--- a/HyperMock/MockProxyDispatcher.cs
+++ b/HyperMock/MockProxyDispatcher.cs
@@ -187,11 +187,11 @@ namespace HyperMock.Universal
                 throw new MockException(CreateMissingMockMethodMessage(targetMethod, args));
             }
 
-            if (matchedCallInfo.ExceptionType != null)
+            if (matchedCallInfo.Exception != null)
             {
-                var exception = (Exception)Activator.CreateInstance(matchedCallInfo.ExceptionType);
                 matchedCallInfo.Visited++;
-                throw exception;
+
+                throw matchedCallInfo.Exception;
             }
 
             matchedCallInfo.Visited++;

--- a/HyperMock/ReturnBehaviour.cs
+++ b/HyperMock/ReturnBehaviour.cs
@@ -1,5 +1,7 @@
 ﻿namespace HyperMock.Universal
 {
+    using System;
+
     /// <summary>
     /// Provides return type behaviours to be added.
     /// </summary>
@@ -28,8 +30,23 @@
         /// </summary>
         /// <typeparam name="TException">Exception type</typeparam>
         public void Throws<TException>()
+            where TException : Exception, new()
         {
-            _callInfo.ExceptionType = typeof(TException);
+            this.Throws(new TException());
+        }
+
+        /// <summary>
+        /// The mocked type method or parameter throws an exception.
+        /// </summary>
+        /// <param name="exception">Exception instance to throw</param>
+        public void Throws(Exception exception)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException(nameof(exception));
+            }
+
+            _callInfo.Exception = exception;
         }
     }
 }

--- a/HyperMock/VoidBehaviour.cs
+++ b/HyperMock/VoidBehaviour.cs
@@ -1,5 +1,7 @@
 ﻿namespace HyperMock.Universal
 {
+    using System;
+
     /// <summary>
     /// Provides void method behaviours to be added.
     /// </summary>
@@ -17,8 +19,23 @@
         /// </summary>
         /// <typeparam name="TException">Exception type</typeparam>
         public void Throws<TException>()
+            where TException : Exception, new()
         {
-            _callInfo.ExceptionType = typeof(TException);
+            this.Throws(new TException());
+        }
+
+        /// <summary>
+        /// The mocked type method or parameter throws an exception.
+        /// </summary>
+        /// <param name="exception">Exception instance to throw</param>
+        public void Throws(Exception exception)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException(nameof(exception));
+            }
+
+            _callInfo.Exception = exception;
         }
     }
 }


### PR DESCRIPTION
Adds an overload for the Throws method that lets the mock's setup code
pass the exception instance that should be thrown upon mock excersice.

This is necessary in cases where the method under test takes some actions
based on the exception properties, enabling more scenarios to be tested.

The main change is in the way the exception is activated, that was
previously placed in the MockProxyDispatcher.Invoke method. To avoid
polluting the CallInfo class, the ExceptionType property was replaced by
the Exception property, which holds the exception to be thrown, whether if
it was set by Throws<T> or Throws(Exception) method.